### PR TITLE
Update to 0.99.3

### DIFF
--- a/io.github.fastrizwaan.WineZGUI.yml
+++ b/io.github.fastrizwaan.WineZGUI.yml
@@ -148,6 +148,6 @@ modules:
       - ./setup --install --flatpak --prefix=/app
     sources:
       - type: git
-        tag: 0.99.2
-        commit: 0544fa93b88888b64c15b9a04647b9591cf0bf66
+        tag: 0.99.3
+        commit: c901e729c5133d334b521906f1de9698d26d232b
         url: https://github.com/fastrizwaan/WineZGUI.git


### PR DESCRIPTION
0.99.3
- [x] Use Runner's wineboot instead of system's wineboot to update/initialize prefix and template
- [x] If system.reg not found in Template update it using ${WINE_CMD} wineboot -u
- [x] Fix system.reg not found after changing template.